### PR TITLE
Run memcached on localhost

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -23,10 +23,18 @@
 use strict;
 use esmith::Build::CreateLinks qw(:all);
 
+my $event = 'nethserver-memcached-update';
+
 #
 # update event
 #
-event_actions('nethserver-memcached-update', qw(
+event_actions( $event , qw(
       initialize-default-databases 00
 ));
 
+#Template to expand
+templates2events("/etc/sysconfig/memcached", $event);
+
+#service to trigger
+event_services( $event , qw(
+      memcached restart));

--- a/root/etc/e-smith/templates/etc/sysconfig/memcached/10base
+++ b/root/etc/e-smith/templates/etc/sysconfig/memcached/10base
@@ -1,0 +1,5 @@
+PORT="11211"
+USER="memcached"
+MAXCONN="1024"
+CACHESIZE="64"
+OPTIONS="-l 127.0.0.1"


### PR DESCRIPTION
Memcached must run on localhost or a FW interface. We do not open a port in the configuration database but if the port `11211` is opened manually by the sysadmin then memcached will be opened

https://community.nethserver.org/t/memcached-causing-ddos-attack/18110

https://github.com/NethServer/dev/issues/6473